### PR TITLE
docs: removing Continuous Integration (CI) badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Unreferenced Files
-[![Continuous Integration (CI)](https://github.com/DeveloperC286/unreferenced_files/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/DeveloperC286/unreferenced_files/actions/workflows/continuous-integration.yml)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![License](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 

--- a/unreferenced_files/README.md
+++ b/unreferenced_files/README.md
@@ -1,6 +1,5 @@
 # Unreferenced Files
 [![crates.io](https://img.shields.io/crates/v/unreferenced_files)](https://crates.io/crates/unreferenced_files)
-[![Continuous Integration (CI)](https://github.com/DeveloperC286/unreferenced_files/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/DeveloperC286/unreferenced_files/actions/workflows/continuous-integration.yml)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![License](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 

--- a/unreferenced_files_lib/README.md
+++ b/unreferenced_files_lib/README.md
@@ -1,7 +1,6 @@
 # Unreferenced Files Library
 [![Documentation](https://docs.rs/unreferenced_files_lib/badge.svg)](https://docs.rs/unreferenced_files_lib)
 [![crates.io](https://img.shields.io/crates/v/unreferenced_files_lib)](https://crates.io/crates/unreferenced_files_lib)
-[![Continuous Integration (CI)](https://github.com/DeveloperC286/unreferenced_files/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/DeveloperC286/unreferenced_files/actions/workflows/continuous-integration.yml)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![License](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 


### PR DESCRIPTION
As the badge is for the latest workflow not the main branch.

We will also not block a release on checks, so need to run the CI workflow on the main branch. The checks are performed as part of the pull request.